### PR TITLE
* Fix "Value should be a JSON object." if snmpwalk reports OID readings errors that not affect SNMP readings.

### DIFF
--- a/LLD.py
+++ b/LLD.py
@@ -7,7 +7,7 @@ import json
 import re
 import subprocess
 import copy
-
+import os
 
 def get_snmpindex(oid, oid_walk):
     re_oid = re.compile('(\.[\d]+)+')
@@ -77,7 +77,8 @@ def main():
     snmp_index = copy.deepcopy(params)
     snmp_index.insert(1, '-Osx')
     snmp_index.append(args.index)
-    out = subprocess.check_output(snmp_index)
+    with open(os.devnull, 'w') as devnull:
+       out = subprocess.check_output(snmp_index, stderr=devnull)
     snmpindex_dict = {}
     for data in out.decode().splitlines():
         array = data.split('=')
@@ -94,7 +95,8 @@ def main():
     for oid_walk, macro in list(zip(args.oid, args.macro)):
         oid_dict = {}
         snmp_oid.append(oid_walk)
-        out = subprocess.check_output(snmp_oid)
+        with open(os.devnull, 'w') as devnull:
+            out = subprocess.check_output(snmp_oid, stderr=devnull)
         snmp_oid.pop()
         for data in out.decode().splitlines():
             array = data.split('=')


### PR DESCRIPTION
Hello!

I found a issue when using this template with Zabbix-Proxy Docker image. A clean install of "apt install snmp" results in successful SNMP readings but some erros in stderr that got merged with LLD.py output. So I'm ignoring stderr from subprocess allowing LLD.py to continue. Failures from readings itself may reflect in LLD.py outputs, so I think ignore stderr is not a big deal.

Can you validate and merge this patch?

Thanks!